### PR TITLE
Remove imagick from travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
   allow_failures:
      - php: nightly
 before_script:
-  - printf "\n" | pecl install imagick
   - composer update $PREFER_LOWEST
 script:
   - ./vendor/bin/phpunit --coverage-clover clover.xml


### PR DESCRIPTION
#### What does this PR do?
For some reason the travis-ci config required imagick to be installed.  I do not know why this was a requirement. This pull request removes imagick install from the config
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
