### PR TITLE
Add $preserveKeys parameter to Arrays::where

### DIFF
--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -169,15 +169,16 @@ final class Arrays
      *
      * @param array[] $array an array of arrays to be checked
      * @param array $conditions array of key/value pairs to filter by
+     * @param bool  $preserveKeys Flag to preserve the original keys of the array
      *
      * @return array the subset
      *
      * @throws \InvalidArgumentException if a value in $array was not an array
      */
-    public static function where(array $array, array $conditions) : array
+    public static function where(array $array, array $conditions, bool $preserveKeys = false) : array
     {
         $result = [];
-        foreach ($array as $item) {
+        foreach ($array as $index => $item) {
             self::ensureIsArray($item, 'a value in $array was not an array');
 
             foreach ($conditions as $key => $value) {
@@ -186,10 +187,10 @@ final class Arrays
                 }
             }
 
-            $result[] = $item;
+            $result[$index] = $item;
         }
 
-        return $result;
+        return $preserveKeys ? $result : array_values($result);
     }
 
     /**

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -266,6 +266,27 @@ final class ArraysTest extends TestCase
     /**
      * @test
      * @covers ::where
+     */
+    public function wherePreservesOriginalKeys()
+    {
+        $array = [
+            7 => ['key 1' => 'a', 'key 2' => 'b'],
+            8 => ['key 1' => 'c', 'key 2' => 'd'],
+            9 => ['key 1' => 'a', 'key 2' => 'c'],
+        ];
+
+        $expected = [
+            7 => ['key 1' => 'a', 'key 2' => 'b'],
+            9 => ['key 1' => 'a', 'key 2' => 'c'],
+        ];
+
+        $result = A::where($array, ['key 1' => 'a'], true);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @test
+     * @covers ::where
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage a value in $array was not an array
      */


### PR DESCRIPTION
#### What does this PR do?
This pull request adds an optional parameter to `Arrays::where` which will preserve the original keys of the array being searched. This parameter is defaulted to `false` to ensure backwards compatibility. 
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
