### PR TITLE
Add Arrays::expand

### DIFF
--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -574,6 +574,22 @@ final class Arrays
         $input[$newKey] = $value;
     }
 
+    /**
+     * @param array  $values Flat array of values.
+     * @param string $key    The key for which each value will be assigned in the resulting nested array.
+     *
+     * @return array
+     */
+    public static function expand(array $values, string $key) : array
+    {
+        $result = [];
+        foreach ($values as $value) {
+            $result[] = [$key => $value];
+        }
+
+        return $result;
+    }
+
     private static function underscoreKeys(array $input) : array
     {
         $copy = [];

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -1007,4 +1007,23 @@ final class ArraysTest extends TestCase
         Arrays::rename($input, 'value', 'values', true);
         $this->assertSame(['id' => 1, 'values' => [1, 2, 3]], $input);
     }
+
+    /**
+     * @test
+     * @covers ::expand
+     */
+    public function expandArray()
+    {
+        $values = ['a', 'b', 'c'];
+        $key = 'id';
+        $result = Arrays::expand($values, $key);
+        $this->assertSame(
+            [
+                ['id' => 'a'],
+                ['id' => 'b'],
+                ['id' => 'c'],
+            ],
+            $result
+        );
+    }
 }


### PR DESCRIPTION
#### What does this PR do?
This pull request adds the `expand` method to the `Arrays` class to convert a flat array to a nested array with each value in a single element identified by the $key parameter
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
